### PR TITLE
Add repositories section to pom.xml so it will build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -13,6 +12,19 @@
   <name>Fedora Repository Audit Module</name>
   <description>The Fedora Commons repository audit module: Provides audit functionality for the Fedora Commons repository framework.</description>
   <packaging>bundle</packaging>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <properties>
     <!-- Use ${project_name} instead of ${project.artifactId} to avoid incorrect


### PR DESCRIPTION
I can build for the release if I have this section added. If this section is missing, I get:

```
[nruest@gorille:fcrepo-audit] (git)-[local-release]-$ mvn release:clean -V
Apache Maven 3.0.5
Maven home: /usr/share/maven
Java version: 1.8.0_45, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-oracle/jre
Default locale: en_CA, platform encoding: UTF-8
OS name: "linux", version: "3.19.0-23-generic", arch: "amd64", family: "unix"
[INFO] Scanning for projects...
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.fcrepo:fcrepo-audit:4.2.1-SNAPSHOT (/home/nruest/git/fcrepo-release/fcrepo-audit/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not find artifact org.fcrepo:fcrepo:pom:4.2.1-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 6, column 11 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```